### PR TITLE
Potential fix for code scanning alert no. 5: Implicit narrowing conversion in compound assignment

### DIFF
--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -841,7 +841,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
     int verticalOffset = textView.getScrollY() + textView.getTotalPaddingTop();
     rootRect.top += verticalOffset;
     rootRect.bottom += verticalOffset;
-    rootRect.left += startXCoordinates + textView.getTotalPaddingLeft() - textView.getScrollX();
+    rootRect.left = (int) (rootRect.left + startXCoordinates + textView.getTotalPaddingLeft() - textView.getScrollX());
 
     // The bounds for multi-line strings should *only* include the first line. This is because for
     // API 25 and below, Talkback's click is triggered at the center point of these bounds, and if


### PR DESCRIPTION
Potential fix for [https://github.com/violetyousif/OmniGymSocialApp/security/code-scanning/5](https://github.com/violetyousif/OmniGymSocialApp/security/code-scanning/5)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `rootRect.left` to `double` to match the type of `startXCoordinates`. However, since `Rect` only accepts `int` values, we need to perform the addition using `double` and then explicitly cast the result to `int` before assigning it back to `rootRect.left`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
