### PR TITLE
Potential fix for code scanning alert no. 53: Use of a broken or weak…

### DIFF
--- a/Fullstack/Backend/requirements.txt
+++ b/Fullstack/Backend/requirements.txt
@@ -21,3 +21,5 @@ typing_extensions==4.12.2
 urllib3==2.3.0
 # Werkzeug==2.3.7
 
+
+argon2-cffi==23.1.0

--- a/Fullstack/Backend/venv/lib/site-packages/rest_framework_simplejwt/authentication.py
+++ b/Fullstack/Backend/venv/lib/site-packages/rest_framework_simplejwt/authentication.py
@@ -137,7 +137,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
         if api_settings.CHECK_REVOKE_TOKEN:
             if validated_token.get(
                 api_settings.REVOKE_TOKEN_CLAIM
-            ) != get_md5_hash_password(user.password):
+            ) != get_argon2_hash_password(user.password):
                 raise AuthenticationFailed(
                     _("The user's password has been changed."), code="password_changed"
                 )

--- a/Fullstack/Backend/venv/lib/site-packages/rest_framework_simplejwt/utils.py
+++ b/Fullstack/Backend/venv/lib/site-packages/rest_framework_simplejwt/utils.py
@@ -7,11 +7,14 @@ from django.conf import settings
 from django.utils.functional import lazy
 
 
-def get_md5_hash_password(password: str) -> str:
+from argon2 import PasswordHasher
+
+def get_argon2_hash_password(password: str) -> str:
     """
-    Returns MD5 hash of the given password
+    Returns Argon2 hash of the given password
     """
-    return hashlib.md5(password.encode()).hexdigest().upper()
+    ph = PasswordHasher()
+    return ph.hash(password)
 
 
 def make_utc(dt: datetime) -> datetime:


### PR DESCRIPTION
… cryptographic hashing algorithm on sensitive data


To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger, more secure hashing algorithm. In this case, we can use the argon2 hashing algorithm, which is specifically designed for password hashing and is computationally expensive, making it resistant to brute-force attacks.

Install the argon2-cffi package if it is not already installed.
Replace the get_md5_hash_password function with a new function that uses the argon2 hashing algorithm.
Update the import statements to include the necessary argon2 module.